### PR TITLE
Never restore stale tox environment caches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt', '**/requirements/*.txt', 'tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-tox-${{ matrix.python-version }}-
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: actions/setup-python@v4


### PR DESCRIPTION
The installed dependencies in tox environments are no longer automatically synced using pip-tools, which means they do not update if they are stale.

We should therefore never use prefix matching for the cache Action for the tox environments, or we will end up restoring a stale environment every time the requirements files change.

This ensures we only restore tox environments when the cache key matches exactly - meaning that all the tox environments should be rebuilt if any of the requirements files changed.