### PR TITLE
Create zip-file in memory and send as a HTTP-attachment

### DIFF
--- a/python/nav/web/seeddb/page/__init__.py
+++ b/python/nav/web/seeddb/page/__init__.py
@@ -47,7 +47,7 @@ def view_switcher(
     list_view=None,
     move_view=None,
     delete_view=None,
-    generate_qr_codes_view=None,
+    download_qr_codes_view=None,
 ):
     """Selects appropriate view depending on POST data."""
     if request.method == 'POST':
@@ -56,5 +56,5 @@ def view_switcher(
         elif 'delete' in request.POST:
             return delete_view(request)
         elif 'qr_code' in request.POST:
-            return generate_qr_codes_view(request)
+            return download_qr_codes_view(request)
     return list_view(request)

--- a/python/nav/web/seeddb/page/netbox/__init__.py
+++ b/python/nav/web/seeddb/page/netbox/__init__.py
@@ -37,7 +37,7 @@ from nav.web.seeddb.utils.move import move
 from nav.web.seeddb.utils.bulk import render_bulkimport
 from nav.web.seeddb.page.netbox.forms import NetboxFilterForm, NetboxMoveForm
 from nav.web.utils import (
-    generate_qr_codes_as_zip_file,
+    generate_qr_codes_zip_response,
 )
 
 
@@ -143,35 +143,7 @@ def netbox_generate_qr_codes(request):
         )
         url_dict[str(netbox)] = url
 
-    qr_codes_zip_file_name = generate_qr_codes_as_zip_file(url_dict=url_dict)
-
-    info = NetboxInfo()
-    query = (
-        Netbox.objects.select_related("room", "category", "type", "organization")
-        .prefetch_related("profiles")
-        .annotate(profile=ArrayAgg("profiles__name"))
-    )
-    filter_form = NetboxFilterForm(request.GET)
-    value_list = (
-        'sysname',
-        'room',
-        'ip',
-        'category',
-        'organization',
-        'profile',
-        'type__name',
-    )
-    return render_list(
-        request,
-        query,
-        value_list,
-        'seeddb-netbox-edit',
-        edit_url_attr='pk',
-        filter_form=filter_form,
-        template='seeddb/list_netbox.html',
-        extra_context=info.template_context
-        | {"qr_codes_zip_file_name": qr_codes_zip_file_name},
-    )
+    return generate_qr_codes_zip_response(url_dict=url_dict)
 
 
 def netbox_move(request):

--- a/python/nav/web/seeddb/page/netbox/__init__.py
+++ b/python/nav/web/seeddb/page/netbox/__init__.py
@@ -66,7 +66,7 @@ def netbox(request):
         list_view=netbox_list,
         move_view=netbox_move,
         delete_view=netbox_delete,
-        generate_qr_codes_view=netbox_generate_qr_codes,
+        download_qr_codes_view=netbox_download_qr_codes,
     )
 
 
@@ -124,8 +124,8 @@ def netbox_pre_deletion_mark(queryset):
     queryset.update(deleted_at=datetime.datetime.now(), up_to_date=False)
 
 
-def netbox_generate_qr_codes(request):
-    """Controller for generating qr codes for netboxes"""
+def netbox_download_qr_codes(request):
+    """Controller for downloading qr codes for netboxes"""
     if not request.POST.getlist('object'):
         new_message(
             request,

--- a/python/nav/web/seeddb/page/room.py
+++ b/python/nav/web/seeddb/page/room.py
@@ -34,7 +34,7 @@ from nav.web.seeddb.utils.delete import render_delete
 from nav.web.seeddb.utils.move import move
 from nav.web.seeddb.utils.bulk import render_bulkimport
 from nav.web.utils import (
-    generate_qr_codes_as_zip_file,
+    generate_qr_codes_zip_response,
 )
 
 from ..forms import RoomForm, RoomFilterForm, RoomMoveForm
@@ -110,21 +110,7 @@ def room_generate_qr_codes(request):
         url = request.build_absolute_uri(reverse('room-info', kwargs={'roomid': id}))
         url_dict[id] = url
 
-    qr_codes_zip_file_name = generate_qr_codes_as_zip_file(url_dict=url_dict)
-
-    info = RoomInfo()
-    value_list = ('id', 'location', 'description', 'position', 'data')
-    query = Room.objects.select_related("location").all()
-    filter_form = RoomFilterForm(request.GET)
-    return render_list(
-        request,
-        query,
-        value_list,
-        'seeddb-room-edit',
-        filter_form=filter_form,
-        extra_context=info.template_context
-        | {"qr_codes_zip_file_name": qr_codes_zip_file_name},
-    )
+    return generate_qr_codes_zip_response(url_dict=url_dict)
 
 
 def room_delete(request, object_id=None):

--- a/python/nav/web/seeddb/page/room.py
+++ b/python/nav/web/seeddb/page/room.py
@@ -65,7 +65,7 @@ def room(request):
         list_view=room_list,
         move_view=room_move,
         delete_view=room_delete,
-        generate_qr_codes_view=room_generate_qr_codes,
+        download_qr_codes_view=room_download_qr_codes,
     )
 
 
@@ -93,8 +93,8 @@ def room_move(request):
     )
 
 
-def room_generate_qr_codes(request):
-    """Controller for generating qr codes for rooms"""
+def room_download_qr_codes(request):
+    """Controller for downloading qr codes for rooms"""
     if not request.POST.getlist('object'):
         new_message(
             request,

--- a/python/nav/web/templates/seeddb/list.html
+++ b/python/nav/web/templates/seeddb/list.html
@@ -24,13 +24,9 @@
           <input type="submit" name="delete" value="Delete selected" class="button small secondary"/>
         {% endif %}
         {% if not hide_qr_code %}
-          <input type="submit" name="qr_code" value="Generate QR codes for selected" class="button small secondary"/>
+          <input type="submit" name="qr_code" value="Download QR codes for selected" class="button small secondary"/>
         {% endif %}
       </div>
-    {% endif %}
-
-    {% if qr_codes_zip_file_name %}
-      <a href="/static/{{ qr_codes_zip_file_name }}" download="nav_qr_codes">Download generated QR Codes</a>
     {% endif %}
 
     <div id="tablewrapper" class="notvisible" data-forpage="{{ request.path }}" data-page="{{ active_page }}">

--- a/python/nav/web/utils.py
+++ b/python/nav/web/utils.py
@@ -139,10 +139,12 @@ def generate_qr_codes_as_byte_strings(url_dict: dict[str, str]) -> list[str]:
 
 def generate_qr_codes_zip_response(url_dict: dict[str, str]) -> FileResponse:
     """
-    Takes a dict of the form {name:url} and a file path and saves a ZIP file
-    containing QR codes as PNGs under the given path, if supplied
+    Takes a dict of the form {name:url} and returns a FileResponse object that
+    represents a ZIP file consisting of named PNG images of QR codes which map
+    each name of the dict to its url.
 
-    Returns the name of the ZIP file
+    Returning the FileResponse in a Django view causes the ZIP file to be delivered
+    in the form of a download attachment in web browsers.
     """
     qr_codes_dict = dict()
     for caption, url in url_dict.items():

--- a/python/nav/web/utils.py
+++ b/python/nav/web/utils.py
@@ -19,8 +19,6 @@ import base64
 import io
 import os
 from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Optional
 import zipfile
 
 from django import forms

--- a/tests/integration/seeddb_test.py
+++ b/tests/integration/seeddb_test.py
@@ -171,8 +171,8 @@ def test_generating_qr_codes_for_netboxes_should_succeed(client, netbox):
     assert "qr_codes.zip" in response.headers["Content-Disposition"]
 
     # Check response content
-    buf = io.BytesIO(response.content)
-    assert ZipFile(buf, "r").namelist == [f"{netbox.id}.png"]
+    buf = io.BytesIO(b"".join(response.streaming_content))
+    assert ZipFile(buf, "r").namelist() == [f"{netbox.sysname}.png"]
 
 
 
@@ -214,8 +214,8 @@ def test_generating_qr_codes_for_rooms_should_succeed(client):
     assert "qr_codes.zip" in response.headers["Content-Disposition"]
 
     # Check response content
-    buf = io.BytesIO(response.content)
-    assert ZipFile(buf, "r").namelist == ["myroom.png"]
+    buf = io.BytesIO(b"".join(response.streaming_content))
+    assert ZipFile(buf, "r").namelist() == ["myroom.png"]
 
 
 def test_generating_qr_codes_for_no_selected_rooms_should_show_error(client, netbox):

--- a/tests/unittests/web/qrcode_test.py
+++ b/tests/unittests/web/qrcode_test.py
@@ -4,7 +4,7 @@ import zipfile
 from nav.web.utils import (
     generate_qr_code,
     generate_qr_codes_as_byte_strings,
-    generate_qr_codes_as_zip_file,
+    generate_qr_codes_zip_response,
 )
 
 
@@ -21,12 +21,34 @@ def test_generate_qr_codes_as_byte_strings_returns_list_of_byte_strings():
     assert isinstance(qr_codes[0], str)
 
 
-def test_generate_qr_codes_as_zip_file_saves_zip_file_under_given_path(tmp_path):
-    file_path = tmp_path / "qr_codes.zip"
-    generate_qr_codes_as_zip_file(
-        {"buick.lab.uninett.no": "www.example.com"}, file_path
-    )
+def test_generate_qr_codes_zip_response_should_return_zip_with_correct_filenames():
+    response = generate_qr_codes_zip_response({
+            "buick.lab.uninett.no": "www.example.com",
+            "buick2.lab.uninett.no": "www2.example.com",
+    })
 
-    assert zipfile.is_zipfile(file_path)
-    file = zipfile.ZipFile(file_path, "r")
-    assert "buick.lab.uninett.no.png" in file.namelist()
+    buf = io.BytesIO(b"".join(response.streaming_content))
+    zip_ = zipfile.ZipFile(buf, "r")
+
+    actual_filenames = sorted(zip_.namelist())
+    expected_filenames = sorted(["buick.lab.uninett.no.png", "buick2.lab.uninett.no.png"])
+
+    assert actual_filenames == expected_filenames
+
+def test_generate_qr_codes_zip_response_should_return_zip_with_correct_content():
+    PNG_MAGIC_BYTES = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+    response = generate_qr_codes_zip_response({
+            "buick.lab.uninett.no": "www.example.com",
+            "buick2.lab.uninett.no": "www2.example.com",
+    })
+
+    buf = io.BytesIO(b"".join(response.streaming_content))
+    zip_ = zipfile.ZipFile(buf, "r")
+
+    zip_has_file = False
+    for filename in zip_.namelist():
+        with zip_.open(filename) as f:
+            assert f.read(len(PNG_MAGIC_BYTES)) == PNG_MAGIC_BYTES
+        zip_has_file = True
+    assert zip_has_file


### PR DESCRIPTION
## Scope and purpose

My attempt at fixing the issues raised in #2899 

### This pull request
1. Fixes the issue of how to handle a ZIP file that is saved to the filesystem during processing by not saving it to the filesystem, but storing it in memory instead.
2. Fixes the issue of how to style the download link by removing it and replacing the "create" form-submit button with a "create and download" button.
3. The issue of where to save the ZIP file is gone since we store it in memory.

Generally speaking, the function `generate_qr_codes_as_zip_file()` has been replaced with `generate_qr_codes_zip_response()`.